### PR TITLE
Table <=> HashMap and fix for entrySet()

### DIFF
--- a/CCLib/src/cc/native/Peripheral.lua
+++ b/CCLib/src/cc/native/Peripheral.lua
@@ -11,7 +11,11 @@ natives["cc.peripheral.Peripheral"]["call(Ljava/lang/String;[Ljava/lang/Object;)
 
     local jRet = newArray(getArrayClass("[Ljava.lang.Object;"), #ret)
     for i,v in ipairs(ret) do
-        jRet[5][i] = l2jType(v)
+        if type(v) == "table" then
+            jRet[5][i] = toJMap(v)
+        else
+            jRet[5][i] = l2jType(v)
+        end
     end
     return jRet
 end

--- a/CCLib/src/java/lang/native/HashMap.lua
+++ b/CCLib/src/java/lang/native/HashMap.lua
@@ -102,8 +102,16 @@ function toJMap(map)
     findMethod(class, "<init>()V")[1](jMap)
     local jPut = findMethod(class, "put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;")[1]
     for key, val in pairs(map) do
-        key = l2jType(key)
-        val = l2jType(val)
+        if type(key) == "table" then
+            key = toJMap(key)
+        else
+            key = l2jType(key)
+        end
+        if type(val) == "table" then
+            val = toJMap(val)
+        else
+            val = l2jType(val)
+        end
         local _, exc = jPut(jMap, key, val)
         if exc then return nil, exc end
     end
@@ -114,8 +122,17 @@ function toLMap(map)
     local lMap = {}
     for _, bucket in pairs(tables[map]) do
         for _, pair in pairs(bucket) do
-            local key = j2lType(pair[1])
-            local val = j2lType(pair[2])
+            local key, val
+            if pair[1][1] == "java.util.HashMap" then
+                key = toLMap(pair[1])
+            else
+                key = j2lType(pair[1])
+            end
+            if pair[2][1] == "java.util.HashMap" then
+                key = toLMap(pair[2])
+            else
+                key = j2lType(pair[2])
+            end
             lMap[key] = val
         end
     end

--- a/CCLib/src/java/lang/native/HashMap.lua
+++ b/CCLib/src/java/lang/native/HashMap.lua
@@ -95,3 +95,29 @@ natives["java.util.HashMap"]["getHash(Ljava/lang/Object;I)Ljava/lang/Object;"] =
         end
     end
 end
+
+function toJMap(map)
+    local class = classByName("java.util.HashMap")
+    local jMap = newInstance(class)
+    findMethod(class, "<init>()V")[1](jMap)
+    local jPut = findMethod(class, "put(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;")[1]
+    for key, val in pairs(map) do
+        key = l2jType(key)
+        val = l2jType(val)
+        local _, exc = jPut(jMap, key, val)
+        if exc then return nil, exc end
+    end
+    return jMap
+end
+
+function toLMap(map)
+    local lMap = {}
+    for _, bucket in pairs(tables[map]) do
+        for _, pair in pairs(bucket) do
+            local key = j2lType(pair[1])
+            local val = j2lType(pair[2])
+            lMap[key] = val
+        end
+    end
+    return lMap;
+end

--- a/CCLib/src/java/util/HashMap.java
+++ b/CCLib/src/java/util/HashMap.java
@@ -65,13 +65,14 @@ public class HashMap<K, V> implements Map<K, V> {
 			
 			@Override
 			public boolean hasNext() {
-				return i < elements.length - 1;
+				return i < elements.length;
 			}
 
 			@Override
 			public java.util.Map.Entry<K, V> next() {
+				java.util.Map.Entry<K, V> e = elements[i];
 				i++;
-				return elements[i];
+				return e;
 			}
 
 			@Override

--- a/jvml_data/vm/runtime.lua
+++ b/jvml_data/vm/runtime.lua
@@ -235,6 +235,8 @@ function l2jType(v)
         return wrapPrimitive(v and 1 or 0, "Z")
     elseif t == "string" then
         return toJString(v)
+    elseif t == "table" then
+        return toJMap(v)
     else
         error("Unsupported lua type for converting to java: "..t)
     end
@@ -258,6 +260,8 @@ function j2lType(obj)
         return getObjectField(obj, "value")
     elseif n == "java.lang.String" then
         return toLString(obj)
+    elseif n == "java.util.HashMap" then
+        return toLMap(obj)
     else
         error("Unsupported java type for converting to lua: "..n)
     end

--- a/jvml_data/vm/runtime.lua
+++ b/jvml_data/vm/runtime.lua
@@ -235,8 +235,6 @@ function l2jType(v)
         return wrapPrimitive(v and 1 or 0, "Z")
     elseif t == "string" then
         return toJString(v)
-    elseif t == "table" then
-        return toJMap(v)
     else
         error("Unsupported lua type for converting to java: "..t)
     end
@@ -260,8 +258,6 @@ function j2lType(obj)
         return getObjectField(obj, "value")
     elseif n == "java.lang.String" then
         return toLString(obj)
-    elseif n == "java.util.HashMap" then
-        return toLMap(obj)
     else
         error("Unsupported java type for converting to lua: "..n)
     end


### PR DESCRIPTION
The conversion is implicit (added functionality to l2jType() and j2lType()) and recursive. As the peripheral API uses l2jType, it also supports tables now (yay!).

I also found a bug in the entrySet() method, it skipped the first element. Fix is in the PR.
